### PR TITLE
Do not add ModulePartInfo to ThrottleControlledAvionics "parts"

### DIFF
--- a/GameData/PartInfo/PartInfo.cfg
+++ b/GameData/PartInfo/PartInfo.cfg
@@ -1,4 +1,4 @@
-@PART[*]:Final
+@PART[*]:HAS[~name[TCAModule*]]:FINAL
 {
 	MODULE
 	{


### PR DESCRIPTION
ThrottleControlledAvionics uses dummy parts for tech tree unlocks of its modules.
Do not add ModulePartInfo to them.